### PR TITLE
Display IP address

### DIFF
--- a/IoT/README.md
+++ b/IoT/README.md
@@ -7,11 +7,12 @@ Here belong all the projects that consist IoT applications based on the RPi.
 - [PiLock](https://github.com/kerk12/PiLock)
 A Simple RPi controlled door lock system. Uses an RPi and an Arduino and can be hooked up to an existing door unlock circuit (for example, at an apartment building). The whole contraption is controlled by the [official app](https://github.com/kerk12/PiLockApp). Coded by Kyriakos Giannakis (kerk12gr@gmail.com).
 
-- [GreenPiThumb]
+- GreenPiThumb
+
 GreenPiThumb is a program that automatically waters a plant based on soil moisture levels, and records and displays the following:
 
-Ambient temperature
-Ambient humidity
-Ambient light
-Soil moisture level
-Photographs of the plant
+Ambient temperature, 
+Ambient humidity, 
+Ambient light, 
+Soil moisture level, 
+Photographs of the plant.

--- a/IoT/README.md
+++ b/IoT/README.md
@@ -6,3 +6,12 @@ Here belong all the projects that consist IoT applications based on the RPi.
 
 - [PiLock](https://github.com/kerk12/PiLock)
 A Simple RPi controlled door lock system. Uses an RPi and an Arduino and can be hooked up to an existing door unlock circuit (for example, at an apartment building). The whole contraption is controlled by the [official app](https://github.com/kerk12/PiLockApp). Coded by Kyriakos Giannakis (kerk12gr@gmail.com).
+
+- [GreenPiThumb]
+GreenPiThumb is a program that automatically waters a plant based on soil moisture levels, and records and displays the following:
+
+Ambient temperature
+Ambient humidity
+Ambient light
+Soil moisture level
+Photographs of the plant

--- a/weather_conditions
+++ b/weather_conditions
@@ -1,0 +1,39 @@
+#Get weather conditions on your pi using API darksky https://darksky.net/dev/docs you need to register and get the API key (it's free)
+from urllib2 import urlopen
+import json
+import time
+
+
+apikey="yourapikey"
+lati =""  #find your latitude and longitude from google maps. 
+longi = ""
+
+try:
+#get the data from the api website
+ url="https://api.forecast.io/forecast/"+apikey+"/"+lati+","+longi+"?units=si"
+ oldTemp = 0          
+#in case the Internet is not working: try it but then use the oldTemp just in case
+ try:
+  meteo=urlopen(url).read()
+  meteo = meteo.decode('utf-8')
+  weather = json.loads(meteo)        
+  currentTemp = weather['currently']['temperature']        
+  condition = weather['currently']['icon']
+  wind = weather['currently']['windSpeed']
+ except IOError:           
+  currentTemp = oldTemp
+    
+  oldTemp = currentTemp #set oldTemp to last known temperature
+
+ print currentTemp
+ print condition
+ print wind
+ 
+ #Weather conditions will be written on a file txt
+ mytemp=str(condition) +" "+ str(currentTemp)+" "+str(wind)
+ file = open('temp.txt','w') 
+ 
+ file.write(mytemp) 
+
+except KeyboardInterrupt:
+ print("Exit")

--- a/weather_conditions
+++ b/weather_conditions
@@ -34,6 +34,33 @@ try:
  file = open('temp.txt','w') 
  
  file.write(mytemp) 
+ 
+ 
+ #use different colour LED to display temperature (e.g. red if temperature over 25C, yellow if temperature over 17C etc..."
+ 
+ if 0 < currentTemp < 10:
+  GPIO.output(27,GPIO.HIGH)
+  GPIO.output(23,GPIO.LOW) 
+  GPIO.output(22,GPIO.LOW) 
+  GPIO.output(24,GPIO.LOW)
+ 
+ if 10 < currentTemp < 17:
+  GPIO.output(24,GPIO.HIGH)
+  GPIO.output(23,GPIO.LOW)
+  GPIO.output(22,GPIO.LOW)
+  GPIO.output(27,GPIO.LOW)
+
+ if 17 < currentTemp < 25:
+  GPIO.output(23,GPIO.HIGH)
+  GPIO.output(24,GPIO.LOW)
+  GPIO.output(22,GPIO.LOW) 
+  GPIO.output(27,GPIO.LOW)
+
+ if currentTemp > 25: 
+  GPIO.output(22,GPIO.HIGH)
+  GPIO.output(23,GPIO.LOW)
+  GPIO.output(24,GPIO.LOW)
+  GPIO.output(27,GPIO.LOW)
 
 except KeyboardInterrupt:
  print("Exit")


### PR DESCRIPTION
`import socket 
import time 
import unicornhat as unicorn 
 
# From http://commandline.org.uk/python/how-to-find-out-ip-address-in-python/ 
def getNetworkIp(): 
   s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
   s.connect(('google.com', 0)) 
   return s.getsockname()[0] 
 
# Prepare the Unicorn pHAT display
unicorn.set_layout(unicorn.PHAT) 
unicorn.rotation(0) 
unicorn.brightness(0.5) 
 
# Obtain our IP address and split it into the 4 components ("octets")
ip = getNetworkIp() 
octets = ip.split('.') 
 
# Render the binary representation for each octet
y = 0 
for octet in octets: 
 bits = '{0:08b}'.format(int(octet)) 
 x = 0 
 for b in bits: 
   if int(b): 
     unicorn.set_pixel(x, y, 0, 0, 128) 
   x += 1 
 y += 1 
 
# Render the display
unicorn.show() `